### PR TITLE
feat: add `CommandList.stringify()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ import { parse } from 'svg-path-command'
 // const { parse } = require('svg-path-command') // If CommonJS
 
 const pathCommand = parse('M2,8 L5,2 L8,8')
-
 console.log(pathCommand.commands)
 /*
 [
@@ -44,6 +43,12 @@ console.log(pathCommand.commands)
   },
 ]
 */
+
+pathCommand.commands[1].updateResult({
+  x: 10,
+  y: 12,
+})
+console.log(pathCommand.stringify()) // 'M2,8 L5,2 L8,8'
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pathCommand.commands[1].updateResult({
   x: 10,
   y: 12,
 })
-console.log(pathCommand.stringify()) // 'M2,8 L5,2 L8,8'
+console.log(pathCommand.stringify()) // 'M2,8 L10,12 L8,8'
 ```
 
 ## License

--- a/lib/Command/A.spec.ts
+++ b/lib/Command/A.spec.ts
@@ -51,16 +51,13 @@ describe('AbsoluteACommand', () => {
       x: 700,
       y: 800,
     }
-    command.result = NEW_RESULT
-    const params = command.unmarshall()
+    command.updateResult(NEW_RESULT)
 
-    expect(params).toEqual(NEW_PARAMS)
     expect(command.params).toEqual(NEW_PARAMS)
     expect(command.result).toEqual(NEW_RESULT)
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -107,16 +104,13 @@ describe('RelativeACommand', () => {
       dx: 700,
       dy: 800,
     }
-    command.result = NEW_RESULT
-    const params = command.unmarshall()
+    command.updateResult(NEW_RESULT)
 
-    expect(params).toEqual(NEW_PARAMS)
     expect(command.params).toEqual(NEW_PARAMS)
     expect(command.result).toEqual(NEW_RESULT)
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/A.ts
+++ b/lib/Command/A.ts
@@ -26,7 +26,9 @@ export class AbsoluteACommand extends Command<
       x: this.params[4],
       y: this.params[5],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -44,7 +46,8 @@ export class AbsoluteACommand extends Command<
       result.x,
       result.y,
     ]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -80,7 +83,9 @@ export class RelativeACommand extends Command<
       dx: this.params[4],
       dy: this.params[5],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -98,7 +103,8 @@ export class RelativeACommand extends Command<
       result.dx,
       result.dy,
     ]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/C.spec.ts
+++ b/lib/Command/C.spec.ts
@@ -51,16 +51,13 @@ describe('AbsoluteCCommand', () => {
       x: 1100,
       y: 1200,
     }
-    command.result = NEW_RESULT
-    const params = command.unmarshall()
+    command.updateResult(NEW_RESULT)
 
-    expect(params).toEqual(NEW_PARAMS)
     expect(command.params).toEqual(NEW_PARAMS)
     expect(command.result).toEqual(NEW_RESULT)
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -107,16 +104,13 @@ describe('RelativeCCommand', () => {
       dx: 1100,
       dy: 1200,
     }
-    command.result = NEW_RESULT
-    const params = command.unmarshall()
+    command.updateResult(NEW_RESULT)
 
-    expect(params).toEqual(NEW_PARAMS)
     expect(command.params).toEqual(NEW_PARAMS)
     expect(command.result).toEqual(NEW_RESULT)
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/C.ts
+++ b/lib/Command/C.ts
@@ -26,7 +26,9 @@ export class AbsoluteCCommand extends Command<
       x: this.params[4],
       y: this.params[5],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -44,7 +46,8 @@ export class AbsoluteCCommand extends Command<
       result.x,
       result.y,
     ]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -80,7 +83,9 @@ export class RelativeCCommand extends Command<
       dx: this.params[4],
       dy: this.params[5],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -98,7 +103,8 @@ export class RelativeCCommand extends Command<
       result.dx,
       result.dy,
     ]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/Command.spec.ts
+++ b/lib/Command/Command.spec.ts
@@ -39,3 +39,10 @@ describe('Command', () => {
     expect(command.validateResult({})).toBeTruthy()
   })
 })
+
+describe('Command.stringify()', () => {
+  test('L100,100', async () => {
+    const command = new Command('L', [100, 100])
+    expect(command.stringify()).toBe('L100,100')
+  })
+})

--- a/lib/Command/Command.spec.ts
+++ b/lib/Command/Command.spec.ts
@@ -38,11 +38,4 @@ describe('Command', () => {
     expect(command.validateResult(undefined)).toBeFalsy()
     expect(command.validateResult({})).toBeTruthy()
   })
-
-  test('throw set invalid params', async () => {
-    expect(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      command.params = 100 as any
-    }).toThrow('Invalid params array')
-  })
 })

--- a/lib/Command/Command.ts
+++ b/lib/Command/Command.ts
@@ -68,6 +68,10 @@ export class Command<
     return []
   }
 
+  stringify(): string {
+    return this._command + this._params.join(',')
+  }
+
   // TODO: deprecate
   validate(): boolean {
     return this.validateParams(this._params)

--- a/lib/Command/Command.ts
+++ b/lib/Command/Command.ts
@@ -38,33 +38,34 @@ export class Command<
     return this._params
   }
 
-  set params(value: number[]) {
-    if (!this.validateParams(value)) {
-      throw new ParserError('Invalid params array')
-    }
-
-    this._params = value
-  }
-
   get result(): Result | undefined {
     return this._result
   }
 
-  set result(value: Result | undefined) {
-    this._result = value
+  protected setParams(value: number[]) {
+    this._params = value
+  }
+
+  protected setResult(result: Result | undefined) {
+    this._result = result
+  }
+
+  updateParams(params: number[]) {
+    this.setParams(params)
+    this.marshall()
+  }
+
+  updateResult(result: Result | undefined) {
+    this.setResult(result)
+    this.unmarshall()
   }
 
   marshall(): Result | undefined {
-    const result: Result | undefined = undefined
-    this._result = result
-    return result
+    return undefined
   }
 
   unmarshall(): number[] {
-    const params: number[] = []
-    this._params = params
-
-    return params
+    return []
   }
 
   // TODO: deprecate

--- a/lib/Command/H.spec.ts
+++ b/lib/Command/H.spec.ts
@@ -25,17 +25,13 @@ describe('AbsoluteHCommand', () => {
 
     expect(result).toEqual({ x: 100 })
 
-    command.result = { x: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ x: 200 })
 
-    expect(params).toEqual([200])
     expect(command.params).toEqual([200])
     expect(command.result).toEqual({ x: 200 })
 
-    command.result = undefined
-
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -71,16 +67,13 @@ describe('RelativeHCommand', () => {
 
     expect(result).toEqual({ dx: 100 })
 
-    command.result = { dx: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ dx: 200 })
 
-    expect(params).toEqual([200])
     expect(command.params).toEqual([200])
     expect(command.result).toEqual({ dx: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/H.ts
+++ b/lib/Command/H.ts
@@ -17,7 +17,9 @@ export class AbsoluteHCommand extends Command<
     const result: AbsoluteHCommandParseResult = {
       x: this.params[0],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -28,7 +30,8 @@ export class AbsoluteHCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.x]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -52,7 +55,9 @@ export class RelativeHCommand extends Command<
     const result: RelativeHCommandParseResult = {
       dx: this.params[0],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -63,7 +68,8 @@ export class RelativeHCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.dx]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/L.spec.ts
+++ b/lib/Command/L.spec.ts
@@ -28,16 +28,13 @@ describe('AbsoluteLCommand', () => {
     command.marshall()
     expect(command.result).toEqual(ABSOLUTE_RESULT)
 
-    command.result = { x: 200, y: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ x: 200, y: 200 })
 
-    expect(params).toEqual([200, 200])
     expect(command.params).toEqual([200, 200])
     expect(command.result).toEqual({ x: 200, y: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -75,16 +72,13 @@ describe('RelativeLCommand', () => {
     command.marshall()
     expect(command.result).toEqual(RELATIVE_RESULT)
 
-    command.result = { dx: 200, dy: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ dx: 200, dy: 200 })
 
-    expect(params).toEqual([200, 200])
     expect(command.params).toEqual([200, 200])
     expect(command.result).toEqual({ dx: 200, dy: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/L.ts
+++ b/lib/Command/L.ts
@@ -18,7 +18,9 @@ export class AbsoluteLCommand extends Command<
       x: this.params[0],
       y: this.params[1],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -29,7 +31,8 @@ export class AbsoluteLCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.x, result.y]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -54,7 +57,9 @@ export class RelativeLCommand extends Command<
       dx: this.params[0],
       dy: this.params[1],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -65,7 +70,8 @@ export class RelativeLCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.dx, result.dy]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/M.spec.ts
+++ b/lib/Command/M.spec.ts
@@ -28,16 +28,13 @@ describe('AbsoluteMCommand', () => {
     command.marshall()
     expect(command.result).toEqual(ABSOLUTE_RESULT)
 
-    command.result = { x: 200, y: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ x: 200, y: 200 })
 
-    expect(params).toEqual([200, 200])
     expect(command.params).toEqual([200, 200])
     expect(command.result).toEqual({ x: 200, y: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -75,16 +72,13 @@ describe('RelativeMCommand', () => {
     command.marshall()
     expect(command.result).toEqual(RELATIVE_RESULT)
 
-    command.result = { dx: 200, dy: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ dx: 200, dy: 200 })
 
-    expect(params).toEqual([200, 200])
     expect(command.params).toEqual([200, 200])
     expect(command.result).toEqual({ dx: 200, dy: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/M.ts
+++ b/lib/Command/M.ts
@@ -18,7 +18,9 @@ export class AbsoluteMCommand extends Command<
       x: this.params[0],
       y: this.params[1],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -29,7 +31,8 @@ export class AbsoluteMCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.x, result.y]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -54,7 +57,9 @@ export class RelativeMCommand extends Command<
       dx: this.params[0],
       dy: this.params[1],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -65,7 +70,8 @@ export class RelativeMCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.dx, result.dy]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/Q.spec.ts
+++ b/lib/Command/Q.spec.ts
@@ -45,16 +45,14 @@ describe('AbsoluteQCommand', () => {
       x: 700,
       y: 800,
     }
-    command.result = NEW_RESULT
-    const params = command.unmarshall()
 
-    expect(params).toEqual(NEW_PARAMS)
+    command.updateResult(NEW_RESULT)
+
     expect(command.params).toEqual(NEW_PARAMS)
     expect(command.result).toEqual(NEW_RESULT)
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -99,16 +97,14 @@ describe('RelativeQCommand', () => {
       dx: 700,
       dy: 800,
     }
-    command.result = NEW_RESULT
-    const params = command.unmarshall()
 
-    expect(params).toEqual(NEW_PARAMS)
+    command.updateResult(NEW_RESULT)
+
     expect(command.params).toEqual(NEW_PARAMS)
     expect(command.result).toEqual(NEW_RESULT)
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/Q.ts
+++ b/lib/Command/Q.ts
@@ -24,7 +24,9 @@ export class AbsoluteQCommand extends Command<
       x: this.params[2],
       y: this.params[3],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -35,7 +37,8 @@ export class AbsoluteQCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.x1, result.y1, result.x, result.y]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -67,7 +70,9 @@ export class RelativeQCommand extends Command<
       dx: this.params[2],
       dy: this.params[3],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -78,7 +83,8 @@ export class RelativeQCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.dx1, result.dy1, result.dx, result.dy]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/S.spec.ts
+++ b/lib/Command/S.spec.ts
@@ -45,16 +45,14 @@ describe('AbsoluteSCommand', () => {
       x: 700,
       y: 800,
     }
-    command.result = NEW_RESULT
-    const params = command.unmarshall()
 
-    expect(params).toEqual(NEW_PARAMS)
+    command.updateResult(NEW_RESULT)
+
     expect(command.params).toEqual(NEW_PARAMS)
     expect(command.result).toEqual(NEW_RESULT)
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -99,16 +97,14 @@ describe('RelativeSCommand', () => {
       dx: 700,
       dy: 800,
     }
-    command.result = NEW_RESULT
-    const params = command.unmarshall()
 
-    expect(params).toEqual(NEW_PARAMS)
+    command.updateResult(NEW_RESULT)
+
     expect(command.params).toEqual(NEW_PARAMS)
     expect(command.result).toEqual(NEW_RESULT)
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/S.ts
+++ b/lib/Command/S.ts
@@ -24,7 +24,9 @@ export class AbsoluteSCommand extends Command<
       x: this.params[2],
       y: this.params[3],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -35,7 +37,8 @@ export class AbsoluteSCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.x2, result.y2, result.x, result.y]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -67,7 +70,9 @@ export class RelativeSCommand extends Command<
       dx: this.params[2],
       dy: this.params[3],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -78,7 +83,8 @@ export class RelativeSCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.dx2, result.dy2, result.dx, result.dy]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/T.spec.ts
+++ b/lib/Command/T.spec.ts
@@ -28,16 +28,13 @@ describe('AbsoluteTCommand', () => {
     command.marshall()
     expect(command.result).toEqual(ABSOLUTE_RESULT)
 
-    command.result = { x: 200, y: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ x: 200, y: 200 })
 
-    expect(params).toEqual([200, 200])
     expect(command.params).toEqual([200, 200])
     expect(command.result).toEqual({ x: 200, y: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -75,16 +72,13 @@ describe('RelativeTCommand', () => {
     command.marshall()
     expect(command.result).toEqual(RELATIVE_RESULT)
 
-    command.result = { dx: 200, dy: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ dx: 200, dy: 200 })
 
-    expect(params).toEqual([200, 200])
     expect(command.params).toEqual([200, 200])
     expect(command.result).toEqual({ dx: 200, dy: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/T.ts
+++ b/lib/Command/T.ts
@@ -18,7 +18,9 @@ export class AbsoluteTCommand extends Command<
       x: this.params[0],
       y: this.params[1],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -29,7 +31,8 @@ export class AbsoluteTCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.x, result.y]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -54,7 +57,9 @@ export class RelativeTCommand extends Command<
       dx: this.params[0],
       dy: this.params[1],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -65,7 +70,8 @@ export class RelativeTCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.dx, result.dy]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/V.spec.ts
+++ b/lib/Command/V.spec.ts
@@ -25,16 +25,13 @@ describe('AbsoluteVCommand', () => {
 
     expect(result).toEqual({ y: 100 })
 
-    command.result = { y: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ y: 200 })
 
-    expect(params).toEqual([200])
     expect(command.params).toEqual([200])
     expect(command.result).toEqual({ y: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -71,16 +68,13 @@ describe('RelativeVCommand', () => {
 
     expect(result).toEqual({ dy: 100 })
 
-    command.result = { dy: 200 }
-    const params = command.unmarshall()
+    command.updateResult({ dy: 200 })
 
-    expect(params).toEqual([200])
     expect(command.params).toEqual([200])
     expect(command.result).toEqual({ dy: 200 })
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/V.ts
+++ b/lib/Command/V.ts
@@ -17,7 +17,9 @@ export class AbsoluteVCommand extends Command<
     const result: AbsoluteVCommandParseResult = {
       y: this.params[0],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -28,7 +30,8 @@ export class AbsoluteVCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.y]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }
@@ -52,7 +55,9 @@ export class RelativeVCommand extends Command<
     const result: RelativeVCommandParseResult = {
       dy: this.params[0],
     }
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -63,7 +68,8 @@ export class RelativeVCommand extends Command<
 
     const result = { ...this.result }
     const params = [result.dy]
-    this.params = params
+
+    this.setParams(params)
 
     return params
   }

--- a/lib/Command/Z.spec.ts
+++ b/lib/Command/Z.spec.ts
@@ -25,16 +25,13 @@ describe('AbsoluteZCommand', () => {
 
     expect(result).toEqual({})
 
-    command.result = {}
-    const params = command.unmarshall()
+    command.updateResult({})
 
-    expect(params).toEqual([])
     expect(command.params).toEqual([])
     expect(command.result).toEqual({})
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 
@@ -71,16 +68,13 @@ describe('RelativeZCommand', () => {
 
     expect(result).toEqual({})
 
-    command.result = {}
-    const params = command.unmarshall()
+    command.updateResult({})
 
-    expect(params).toEqual([])
     expect(command.params).toEqual([])
     expect(command.result).toEqual({})
 
-    command.result = undefined
     expect(() => {
-      command.unmarshall()
+      command.updateResult(undefined)
     }).toThrow('Invalid result object')
   })
 

--- a/lib/Command/Z.ts
+++ b/lib/Command/Z.ts
@@ -14,7 +14,9 @@ export class AbsoluteZCommand extends Command<
 > {
   marshall(): AbsoluteZCommandParseResult {
     const result: AbsoluteZCommandParseResult = {}
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -23,7 +25,7 @@ export class AbsoluteZCommand extends Command<
       throw new ParserError('Invalid result object')
     }
 
-    this.params = []
+    this.updateParams([])
 
     return []
   }
@@ -45,7 +47,9 @@ export class RelativeZCommand extends Command<
 > {
   marshall(): RelativeZCommandParseResult {
     const result: RelativeZCommandParseResult = {}
-    this.result = result
+
+    this.setResult(result)
+
     return result
   }
 
@@ -54,7 +58,7 @@ export class RelativeZCommand extends Command<
       throw new ParserError('Invalid result object')
     }
 
-    this.params = []
+    this.updateParams([])
 
     return []
   }

--- a/lib/CommandList/CommandList.spec.ts
+++ b/lib/CommandList/CommandList.spec.ts
@@ -15,4 +15,21 @@ describe('CommandList', () => {
     expect(commands[1] instanceof RelativeLCommand).toBe(true)
     expect(commands[2] instanceof AbsoluteZCommand).toBe(true)
   })
+
+  test('stringify()', async () => {
+    const commandList = new CommandList('M100,100 l 50, -50 Z')
+    expect(commandList.stringify()).toBe('M100,100l50,-50Z')
+  })
+
+  test('update command', async () => {
+    const commandList = new CommandList('M2,8 L 5,2 L8, 8Z')
+    commandList.commands[1].updateResult({
+      x: 12,
+      y: 20,
+    } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    expect(commandList.commands[1].params).toEqual([12, 20])
+    expect(commandList.commands[1].result).toEqual({ x: 12, y: 20 })
+    expect(commandList.stringify()).toBe('M2,8L12,20L8,8Z')
+  })
 })

--- a/lib/CommandList/CommandList.ts
+++ b/lib/CommandList/CommandList.ts
@@ -9,7 +9,9 @@ export class CommandList {
 
   parse(commandString: string) {
     const _commands: CommandType[] = []
-    const commandStringList = this.splitCommand(commandString)
+    const commandStringList = commandString.split(
+      new RegExp(`(?=${COMMANDS.join('|')})`, 'g')
+    )
 
     for (const commandString of commandStringList) {
       const commandList = parseCommand(commandString)
@@ -22,7 +24,7 @@ export class CommandList {
     this.commands = _commands
   }
 
-  private splitCommand(command: string): string[] {
-    return command.split(new RegExp(`(?=${COMMANDS.join('|')})`, 'g'))
+  stringify(): string {
+    return this.commands.map((command) => command.stringify()).join('')
   }
 }


### PR DESCRIPTION

```js
import { parse } from 'svg-path-command'

const pathCommand = parse('M2,8 L5,2 L8,8')

pathCommand.commands[1].updateResult({ x: 10, y: 12 })

console.log(pathCommand.stringify()) // 'M2,8 L10,12 L8,8'
```